### PR TITLE
Fixed ownership of constrained Entites

### DIFF
--- a/lua/autorun/sh_CPPI.lua
+++ b/lua/autorun/sh_CPPI.lua
@@ -44,6 +44,15 @@ if SERVER then
 	function ENTITY:CPPISetOwner(ply)
 		self.FPPOwner = ply
 		self.FPPOwnerID = ply:SteamID()
+		if constraint.HasConstraints( self ) then
+			local ConstrainedEntities = constraint.GetAllConstrainedEntities( self )
+			for _,ent in pairs(ConstrainedEntities) do
+				if IsValid(ent) then
+					ent.FPPOwner = ply
+					ent.FPPOwnerID = ply:SteamID()
+				end
+			end
+		end		
 		return true
 	end
 


### PR DESCRIPTION
Constrained Entities had world ownership because ownership of constrained Entities were not set.
