### PR TITLE
Fixed CPPIGetOwner erroring clientside

### DIFF
--- a/lua/autorun/sh_CPPI.lua
+++ b/lua/autorun/sh_CPPI.lua
@@ -35,6 +35,7 @@ end
 
 local ENTITY = FindMetaTable("Entity")
 function ENTITY:CPPIGetOwner()
+	if CLIENT then return nil, CPPI.CPPI_NOTIMPLEMENTED end
 	local Owner = self.FPPOwner
 	if not IsValid(Owner) or not Owner:IsPlayer() then return Owner, self.FPPOwnerID end
 	return Owner, Owner:UniqueID()


### PR DESCRIPTION
FPPOwner is a string of the player's name clientside unlike serverside, where it is the player entity. IsValid(FPPOwner) == error.
