### PR TITLE
Fixed "unknown command" when a non-existent setting is found in the DB

### DIFF
--- a/lua/autorun/server/FPP_Settings.lua
+++ b/lua/autorun/server/FPP_Settings.lua
@@ -188,16 +188,20 @@ end
 concommand.Add("FPP_ShareProp", ShareProp)
 
 local function RetrieveSettings()
-	for k,v in pairs(FPP.Settings) do
+	for k in pairs(FPP.Settings) do
 		FPPDB.Query("SELECT setting, var FROM "..k..";", function(data)
-
-			if data then
-				local i = 0
-				for key, value in pairs(data) do
-					FPP.Settings[k][value.var] = tonumber(value.setting)
-					i = i + 0.05
-					timer.Simple(i, function() RunConsoleCommand("_"..k.."_"..value.var, tonumber(value.setting)) end)
+			if not data then return end
+			local i = 0
+			for _,value in pairs(data) do
+				if FPP.Settings[k][value.var] == nil then
+					-- Likely an old setting that has since been removed from FPP.
+					-- This setting however still exists in the DB. Time to remove it.
+					FPPDB.Query("DELETE FROM "..k.." WHERE var = "..sql.SQLStr(value.var)..";")
+					continue
 				end
+				FPP.Settings[k][value.var] = tonumber(value.setting)
+				i = i + 0.05
+				timer.Simple(i, function() RunConsoleCommand("_"..k.."_"..value.var, tonumber(value.setting)) end)
 			end
 		end)
 	end


### PR DESCRIPTION
If a FPP.Setting is removed then it will still exist in the DB. When these settings are retrieved in the DB then FPP an "unknown command" message will be printed to the console twice every time a player joins the server.

This commit checks if a setting exists and if not, removes it from the DB and skips to the next setting.

Not much of a big deal at the moment but this future proofs things if a setting were to be removed. Or maybe if someone has an old FPP database then this'll clean it up for them.

Also, how have you got merging into darkrpFPP set up? Should I submit another PR for that since it uses MySQLite rather than FPPDB?
