### PR TITLE
Removed unused FPP_GLOBALSETTINGS1.antispeedhack

### DIFF
--- a/lua/autorun/client/FPP_Menu.lua
+++ b/lua/autorun/client/FPP_Menu.lua
@@ -153,7 +153,6 @@ function FPP.AdminMenu(Panel)
 	addchk("Cleanup disconnected players's entities", {"FPP_GLOBALSETTINGS1", "cleanupdisconnected"}, general)
 	addchk("Cleanup admin's entities on disconnect", {"FPP_GLOBALSETTINGS1", "cleanupadmin"}, general)
 	addsldr(300, {"FPP_GLOBALSETTINGS1", "cleanupdisconnectedtime"}, "Deletion time", general, 0)
-	addchk("Anti speedhack(requires changelevel)", {"FPP_GLOBALSETTINGS1", "antispeedhack"}, general)
 	addchk("Anti E2 mingery (mass killing with E2)", {"FPP_GLOBALSETTINGS1", "antie2minge"}, general)
 
 	local delnow = general:Add("DButton")

--- a/lua/autorun/sh_settings.lua
+++ b/lua/autorun/sh_settings.lua
@@ -70,7 +70,6 @@ FPP.Settings.FPP_GLOBALSETTINGS1 = {
 	cleanupdisconnected = 1,
 	cleanupdisconnectedtime = 120,
 	cleanupadmin = 1,
-	antispeedhack = 0,
 	antie2minge = 1}
 FPP.Settings.FPP_ANTISPAM1 = {
 	toggle = 1,


### PR DESCRIPTION
The implementation was removed 4 years ago. If #52 is merged then this should have no side-effects.
