### PR TITLE
Small Error/Bug Fix

### DIFF
--- a/lua/fpp/server/settings.lua
+++ b/lua/fpp/server/settings.lua
@@ -692,6 +692,10 @@ local function SendBlockedModels(ply, cmd, args)
     for k,v in pairs(FPP.BlockedModels) do table.insert(models, k) end
 
     local data = util.Compress(table.concat(models, "\0"))
+    if data == nil then
+        data = ""
+        return data
+    end
     net.Start("FPP_BlockedModels")
         net.WriteData(data, #data)
     net.Send(ply)


### PR DESCRIPTION
If you have no blocked models, an error will occur when looking at the list of blocked models saying "attempt to get length of local 'data' (a nil value)" directing to line 696.

This will provide a check, in which case it will omit this error if there are no blocked models.