### PR TITLE
Changed the distance for the prop ownership thingy

### DIFF
--- a/lua/fpp/client/hud.lua
+++ b/lua/fpp/client/hud.lua
@@ -170,7 +170,7 @@ local function HUDPaint()
     --Show the owner:
     local ply = LocalPlayer()
 
-    local LAEnt2 = ents.FindAlongRay(ply:EyePos(), ply:EyePos() + EyeAngles():Forward() * 400)
+    local LAEnt2 = ents.FindAlongRay(ply:EyePos(), ply:EyePos() + EyeAngles():Forward() * 16384)
 
     local LAEnt = FilterEntityTable(LAEnt2)[1]
     if not IsValid(LAEnt) then return end


### PR DESCRIPTION
Changed the distance for the prop ownership thingy from 400 to 16384. 400 is insanely tiny. 16384 is the max distance util.GetPlayerTrace uses for its traces. util.GetPlayerTrace is used by Player.GetEyeTraceNoCursor, which is what was used previously.