### PR TITLE
Reduce __index calls for optimization

### DIFF
--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -2,6 +2,9 @@ FPP = FPP or {}
 local plyMeta = FindMetaTable("Player")
 local entMeta = FindMetaTable("Entity")
 
+local bit_bor = bit.bor
+local bit_band = bit.band
+
 --[[-------------------------------------------------------------------------
 Entity data explanation.
 Every ent has a field FPPCanTouch. This is a table with one entry per player.
@@ -241,14 +244,24 @@ end
 Touch interface
 ---------------------------------------------------------------------------]]
 function FPP.plyCanTouchEnt(ply, ent, touchType)
-    ent.FPPCanTouch = ent.FPPCanTouch or {}
-    ent.FPPCanTouch[ply] = ent.FPPCanTouch[ply] or 0
-    ent.AllowedPlayers = ent.AllowedPlayers or {}
+    local entTable = ent:GetTable()
+    local entCanTouch = entTable.FPPCanTouch
+    if not entCanTouch then
+        entTable.FPPCanTouch = {}
+    end
 
-    local canTouch = ent.FPPCanTouch[ply]
+    entCanTouch[ply] = entCanTouch[ply] or 0
+
+    local allowedPlayers = entTable.AllowedPlayers
+    if not allowedPlayers then
+        entTable.AllowedPlayers = {}
+    end
+
+    local canTouch = FPPCanTouch[ply]
     -- if an entity is constrained, return the least of the rights
-    if ent.FPPRestrictConstraint and ent.FPPRestrictConstraint[ply] then
-        canTouch = bit.band(ent.FPPRestrictConstraint[ply], ent.FPPCanTouch[ply])
+    local entRestrictConstraint = entTable.FPPRestrictConstraint
+    if entRestrictConstraint and entRestrictConstraint[ply] then
+        canTouch = bit_band(entRestrictConstraint[ply], entCanTouch[ply])
     end
 
     -- return the answer for every touch type if parameter is empty
@@ -256,11 +269,11 @@ function FPP.plyCanTouchEnt(ply, ent, touchType)
         return canTouch
     end
 
-    return bit.bor(canTouch, touchTypes[touchType]) == canTouch
+    return bit_bor(canTouch, touchTypes[touchType]) == canTouch
 end
 
 function FPP.entGetOwner(ent)
-    return ent.FPPOwner
+    return ent:GetTable().FPPOwner
 end
 
 --[[-------------------------------------------------------------------------


### PR DESCRIPTION
After doing some performance checks i noticed that FPP was doing a lot of avoidable ent.__index calls which are pretty laggy calls.

Example of their impact: https://github.com/Facepunch/garrysmod/pull/2010

With ~30-40 players on sandbox this function accounted for 40k __index calls over the span of 10s. So this change will have a significiant impact.