### PR TITLE
Rework networking logic

### DIFF
--- a/lua/fpp/client/ownability.lua
+++ b/lua/fpp/client/ownability.lua
@@ -26,8 +26,8 @@ local reasons = {
 
 local function receiveTouchData(len)
     repeat
-        local entIndex = net.ReadUInt(32)
-        local ownerIndex = net.ReadUInt(32)
+        local entIndex = net.ReadUInt(13)
+        local ownerIndex = net.ReadUInt(8)
         local touchability = net.ReadUInt(5)
         local reason = net.ReadUInt(20)
 

--- a/lua/fpp/client/ownability.lua
+++ b/lua/fpp/client/ownability.lua
@@ -24,8 +24,10 @@ local reasons = {
     [8] = "player", -- you can't pick up players
 }
 
-local function receiveTouchData(len)
-    repeat
+local function receiveTouchData()
+    for i = 1, 1400 do
+        if net.ReadBit() == 1 then break end
+
         local entIndex = net.ReadUInt(13)
         local ownerIndex = net.ReadUInt(8)
         local touchability = net.ReadUInt(5)
@@ -34,7 +36,7 @@ local function receiveTouchData(len)
         FPP.entOwners[entIndex] = ownerIndex
         FPP.entTouchability[entIndex] = touchability
         FPP.entTouchReasons[entIndex] = reason
-    until net.ReadBit() == 1
+    end
 end
 net.Receive("FPP_TouchabilityData", receiveTouchData)
 

--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -299,13 +299,22 @@ local function startNetWriteQueue()
 
     timer.Create( "FPP_TouchabilityQueue", 0, 0, function()
         for ply, entities in pairs(touchabilityDataQueue) do
-            if not IsValid(ply) then touchabilityDataQueue[ply] = nil continue end
+            if not IsValid(ply) then
+                touchabilityDataQueue[ply] = nil
+                continue
+            end
 
             local count = 0
             net.Start("FPP_TouchabilityData")
             for ent in pairs(entities) do
+                if not IsValid(ent) then
+                    touchabilityDataQueue[ply][ent] = nil
+                    continue
+                end
+
                 net.WriteBit(0)
                 netWriteEntData(ply, ent)
+
                 count = count + 1
                 touchabilityDataQueue[ply][ent] = nil
                 if count >= 1400 then

--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -269,7 +269,7 @@ Networking
 util.AddNetworkString("FPP_TouchabilityData")
 -- Sends 13 + 8 + 5 + 20 = 46 bits of ownership data per entity
 local function netWriteEntData(ply, ent)
-    -- EntIndex for when it's out of the PVS of the player`
+    -- EntIndex for when it's out of the PVS of the player
     net.WriteUInt(ent:EntIndex(), 13)
 
     local owner = ent:CPPIGetOwner()

--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -267,13 +267,13 @@ end
 Networking
 ---------------------------------------------------------------------------]]
 util.AddNetworkString("FPP_TouchabilityData")
--- Sends 32 + 32 + 5 + 20 = 89 bits of ownership data per entity
+-- Sends 13	 + 8 + 5 + 20 = 46 bits of ownership data per entity
 local function netWriteEntData(ply, ent)
     -- EntIndex for when it's out of the PVS of the player
-    net.WriteUInt(ent:EntIndex(), 32)
+    net.WriteUInt(ent:EntIndex(), 13)
 
     local owner = ent:CPPIGetOwner()
-    net.WriteUInt(IsValid(owner) and owner:EntIndex() or -1, 32)
+    net.WriteUInt(IsValid(owner) and owner:EntIndex() or -1, 8)
     net.WriteUInt(ent.FPPRestrictConstraint and ent.FPPRestrictConstraint[ply] or ent.FPPCanTouch[ply], 5) -- touchability information
     net.WriteUInt(ent.FPPConstraintReasons and ent.FPPConstraintReasons[ply] or ent.FPPCanTouchWhy[ply], 20) -- reasons
 end


### PR DESCRIPTION
Lowers the net.WriteUInt for the entity index and player index.

Players will only take up ent index spots 1 to 255 as can be seen here
https://github.com/Facepunch/garrysmod/blob/master/garrysmod/lua/includes/extensions/net.lua#L76-L87

Only ~8k networked entities can exist so i lowered the ent index to 13, https://github.com/Facepunch/garrysmod/blob/master/garrysmod/lua/includes/extensions/net.lua#L56-L64

This PR brings the per entity transfer amount from 89bits to 46bits which should help to signficiantly reduce network strain.
I think that the net usage can further be reduced here:
```lua
    net.WriteUInt(ent.FPPConstraintReasons and ent.FPPConstraintReasons[ply] or ent.FPPCanTouchWhy[ply], 20) -- reasons
```
But im not entirely sure what the max size of this bitflag can be and how it could be lowered.

This PR also adds a new net queue system, currently for example when a prop is spawned a net message is sent twice see: https://github.com/FPtje/Falcos-Prop-protection/pull/325#issuecomment-1975209906. With this new system it'd only be send once in the next tick, this will prevent sending multiple net messages for multiple changes in a single tick.
This system will automatically spread out large net messages over multiple ticks to prevent buffer overflows/sending too much in a single burst.
It uses a timer that automatically removes itself once the queue is empty, could be swapped out for a hook instead.
The reason i lowered the count per message from 5825 to 1400 is because we're sending 46bits while the max net message size is 65533bits so 65533÷46.

So tldr: this will reduce the amount of networking when for example a prop is spawned from `89` bits to `46` bits per message and make it so only 1 net message is send per prop spawn instead of two. So this would result in 75% less networking.