### PR TITLE
Fix cantouch regression

### DIFF
--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -247,7 +247,8 @@ function FPP.plyCanTouchEnt(ply, ent, touchType)
     local entTable = ent:GetTable()
     local entCanTouch = entTable.FPPCanTouch
     if not entCanTouch then
-        entTable.FPPCanTouch = {}
+        entCanTouch = {}
+        entTable.FPPCanTouch = entCanTouch
     end
 
     entCanTouch[ply] = entCanTouch[ply] or 0


### PR DESCRIPTION
The plyCanTouchEnt wasn't setting the entCanTouch variable properly.
This PR fixes that regression.

![image](https://github.com/FPtje/Falcos-Prop-protection/assets/69946827/a73bb7cd-32a3-42fe-bb8b-4a166c222892)
