### PR TITLE
Lower net usage

### DIFF
--- a/lua/fpp/client/ownability.lua
+++ b/lua/fpp/client/ownability.lua
@@ -26,8 +26,8 @@ local reasons = {
 
 local function receiveTouchData(len)
     repeat
-        local entIndex = net.ReadUInt(32)
-        local ownerIndex = net.ReadUInt(32)
+        local entIndex = net.ReadUInt(13)
+        local ownerIndex = net.ReadUInt(8)
         local touchability = net.ReadUInt(5)
         local reason = net.ReadUInt(20)
 

--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -281,15 +281,17 @@ end
 Networking
 ---------------------------------------------------------------------------]]
 util.AddNetworkString("FPP_TouchabilityData")
--- Sends 32 + 32 + 5 + 20 = 89 bits of ownership data per entity
+-- Sends 13 + 8 + 5 + 20 = 46 bits of ownership data per entity
 local function netWriteEntData(ply, ent)
     -- EntIndex for when it's out of the PVS of the player
-    net.WriteUInt(ent:EntIndex(), 32)
+    net.WriteUInt(ent:EntIndex(), 13)
 
     local owner = ent:CPPIGetOwner()
-    net.WriteUInt(IsValid(owner) and owner:EntIndex() or -1, 32)
-    net.WriteUInt(ent.FPPRestrictConstraint and ent.FPPRestrictConstraint[ply] or ent.FPPCanTouch[ply], 5) -- touchability information
-    net.WriteUInt(ent.FPPConstraintReasons and ent.FPPConstraintReasons[ply] or ent.FPPCanTouchWhy[ply], 20) -- reasons
+    net.WriteUInt(IsValid(owner) and owner:EntIndex() or -1, 8)
+
+    local entTable = ent:GetTable()
+    net.WriteUInt(entTable.FPPRestrictConstraint and entTable.FPPRestrictConstraint[ply] or entTable.FPPCanTouch[ply], 5) -- touchability information
+    net.WriteUInt(entTable.FPPConstraintReasons and entTable.FPPConstraintReasons[ply] or entTable.FPPCanTouchWhy[ply], 20) -- reasons
 end
 
 function FPP.plySendTouchData(ply, ents)


### PR DESCRIPTION
Cherry picked UInt size & :GetTable() changes from https://github.com/FPtje/Falcos-Prop-protection/pull/325

Based on https://github.com/Facepunch/garrysmod/blob/master/garrysmod/lua/includes/extensions/net.lua#L56-L97, cant directly uses these functions as FPP sents 

I did notice that FPP sends a -1 if the owner isn't valid, but because we're using UInt it'll instead send the max possible int size, this undefined behaviour wont change with this pr.