### PR TITLE
Account properly for -1 on client too

### DIFF
--- a/lua/fpp/client/ownability.lua
+++ b/lua/fpp/client/ownability.lua
@@ -31,6 +31,10 @@ local function receiveTouchData(len)
         local touchability = net.ReadUInt(5)
         local reason = net.ReadUInt(20)
 
+        if ownerIndex == 255 then
+            ownerIndex = -1
+        end
+
         FPP.entOwners[entIndex] = ownerIndex
         FPP.entTouchability[entIndex] = touchability
         FPP.entTouchReasons[entIndex] = reason

--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -287,7 +287,7 @@ local function netWriteEntData(ply, ent)
     net.WriteUInt(ent:EntIndex(), 13)
 
     local owner = ent:CPPIGetOwner()
-    net.WriteUInt(IsValid(owner) and owner:EntIndex() or -1, 8)
+    net.WriteUInt(IsValid(owner) and owner:EntIndex() or 255, 8)
 
     local entTable = ent:GetTable()
     net.WriteUInt(entTable.FPPRestrictConstraint and entTable.FPPRestrictConstraint[ply] or entTable.FPPCanTouch[ply], 5) -- touchability information


### PR DESCRIPTION
As i mentioned in https://github.com/FPtje/Falcos-Prop-protection/pull/330:

"I did notice that FPP sends a -1 if the owner isn't valid, but because we're using UInt it'll instead send the max possible int size, this undefined behaviour wont change with this pr."

This undefined behaviour can now actually lead to issues, if an entity with no owner gets networked its owner now is set to Entity(255), previously because the UInt was so large (4294967295 while only 8192 ents can exist) it'd automatically be a NULL owner. However now because the max UInt is below the max entity count there's a possibility of it being an actual valid entity.
Considering `CPPIGetOwner` always returns a valid player, it's impossible to get more than 128 players so we can assume that any received 255 on the client is a NULL owner.

Feels like a jank fix for a jank problem, i don't see a better way to do this though.