### PR TITLE
Only remove FPP_OriginalOwner if it's the original

### DIFF
--- a/lua/fpp/server/core.lua
+++ b/lua/fpp/server/core.lua
@@ -671,7 +671,7 @@ function FPP.PlayerInitialSpawn(ply)
                 v:CPPISetOwner(ply)
                 table.insert(entities, v)
 
-                if v:GetNW2String("FPP_OriginalOwner", "") ~= "" then
+                if v:GetNW2String("FPP_OriginalOwner") == SteamID then
                     v:SetNW2String("FPP_OriginalOwner", "")
                 end
             end


### PR DESCRIPTION
Fixes the following bug:
A sets B as fallback, logs off
B sets C as fallback, logs off
B logs in, now owns A's props, A's record has been removed A logs in, props have not been returned as the FPP_OriginalOwner nwvar got cleared