### PR TITLE
Run constraint.GetAllConstrainedEntities after timer

### DIFF
--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -503,11 +503,10 @@ local function constraintRemovedTimer(ent1, ent2)
     if not IsValid(ent1) and not IsValid(ent2) then return end
     entMem = {}
 
-    local constrainedEnts1 = constraint.GetAllConstrainedEntities(ent1)
-    FPP.RecalculateConstrainedEntities(player.GetAll(), constrainedEnts1)
-
-    local constrainedEnts2 = constraint.GetAllConstrainedEntities(ent2)
-    FPP.RecalculateConstrainedEntities(player.GetAll(), constrainedEnts2)
+    local allConstrainedEnts = {}
+    table.Add(allConstrainedEnts, constrainedEnts1)
+    table.Add(allConstrainedEnts, constrainedEnts2)
+    FPP.RecalculateConstrainedEntities(player.GetAll(), allConstrainedEnts)
 end
 
 local function handleConstraintRemoved(ent)

--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -499,8 +499,11 @@ function FPP.RecalculateConstrainedEntities(players, entities)
 end
 
 local entMem = {}
-local function constraintRemovedTimer(ent1, ent2, constrainedEnts)
-    if not IsValid(ent1) and not IsValid(ent2) or not constrainedEnts then return end
+local function constraintRemovedTimer(ent1, ent2)
+    if not IsValid(ent1) and not IsValid(ent2) then return end
+
+    local constrainedEnts = constraint.GetAllConstrainedEntities(ent1)
+    if not constrainedEnts then return end
 
     FPP.RecalculateConstrainedEntities(player.GetAll(), constrainedEnts)
     entMem = {}
@@ -516,10 +519,7 @@ local function handleConstraintRemoved(ent)
     entMem[ent1] = true
     entMem[ent2] = true
 
-    -- the constraint is still there, so this includes ent2's constraints
-    local constrainedEnts = constraint.GetAllConstrainedEntities(ent1)
-
-    timer.Create("FPP_ConstraintRemovedTimer", 0, 1, function() constraintRemovedTimer(ent1, ent2, constrainedEnts) end)
+    timer.Create("FPP_ConstraintRemovedTimer", 0, 1, function() constraintRemovedTimer(ent1, ent2) end)
 end
 
 local function onEntityRemoved(ent)

--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -501,12 +501,13 @@ end
 local entMem = {}
 local function constraintRemovedTimer(ent1, ent2)
     if not IsValid(ent1) and not IsValid(ent2) then return end
-
-    local constrainedEnts = constraint.GetAllConstrainedEntities(ent1)
-    if not constrainedEnts then return end
-
-    FPP.RecalculateConstrainedEntities(player.GetAll(), constrainedEnts)
     entMem = {}
+
+    local constrainedEnts1 = constraint.GetAllConstrainedEntities(ent1)
+    FPP.RecalculateConstrainedEntities(player.GetAll(), constrainedEnts1)
+
+    local constrainedEnts2 = constraint.GetAllConstrainedEntities(ent2)
+    FPP.RecalculateConstrainedEntities(player.GetAll(), constrainedEnts2)
 end
 
 local function handleConstraintRemoved(ent)

--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -504,8 +504,8 @@ local function constraintRemovedTimer(ent1, ent2)
     entMem = {}
 
     local allConstrainedEnts = {}
-    table.Add(allConstrainedEnts, constrainedEnts1)
-    table.Add(allConstrainedEnts, constrainedEnts2)
+    table.Add(allConstrainedEnts, constraint.GetAllConstrainedEntities(ent1))
+    table.Add(allConstrainedEnts, constraint.GetAllConstrainedEntities(ent2))
     FPP.RecalculateConstrainedEntities(player.GetAll(), allConstrainedEnts)
 end
 


### PR DESCRIPTION
Currently every removed constraint being removed triggers `constraint.GetAllConstrainedEntities` which is a pretty expensive function to run, considering its output is only used when ent1 and ent2 are valid it seems like it can be just ran after it. This saves a lot of lag when a large dupe is removed.

Before:
![image](https://github.com/user-attachments/assets/6d324c91-45b3-4e0d-b003-367b20148e39)

After:
![image](https://github.com/user-attachments/assets/1d4c5057-997e-480e-84f6-c51aee549f73)
