### PR TITLE
Improve possible compatibility

### DIFF
--- a/lua/fpp/server/antispam.lua
+++ b/lua/fpp/server/antispam.lua
@@ -4,7 +4,7 @@ FPP.AntiSpam = FPP.AntiSpam or {}
 function FPP.AntiSpam.GhostFreeze(ent, phys)
     ent:SetRenderMode(RENDERMODE_TRANSCOLOR)
     ent:DrawShadow(false)
-    ent.OldColor = ent.OldColor or ent:GetColor()
+    ent.OldColor = IsColor(ent.OldColor) or ent:GetColor()
     ent.StartPos = ent:GetPos()
     ent:SetColor(Color(ent.OldColor.r, ent.OldColor.g, ent.OldColor.b, ent.OldColor.a - 155))
 
@@ -23,7 +23,7 @@ function FPP.UnGhost(ply, ent)
         ent:DrawShadow(true)
         if ent.OldCollisionGroup then ent:SetCollisionGroup(ent.OldCollisionGroup) ent.OldCollisionGroup = nil end
 
-        if ent.OldColor then
+        if IsColor(ent.OldColor) then
             ent:SetColor(Color(ent.OldColor.r, ent.OldColor.g, ent.OldColor.b, ent.OldColor.a))
         end
         ent.OldColor = nil

--- a/lua/fpp/server/antispam.lua
+++ b/lua/fpp/server/antispam.lua
@@ -4,9 +4,9 @@ FPP.AntiSpam = FPP.AntiSpam or {}
 function FPP.AntiSpam.GhostFreeze(ent, phys)
     ent:SetRenderMode(RENDERMODE_TRANSCOLOR)
     ent:DrawShadow(false)
-    ent.OldColor = IsColor(ent.OldColor) or ent:GetColor()
+    ent.FPPOldColor = ent.FPPOldColor or ent:GetColor()
     ent.StartPos = ent:GetPos()
-    ent:SetColor(Color(ent.OldColor.r, ent.OldColor.g, ent.OldColor.b, ent.OldColor.a - 155))
+    ent:SetColor(Color(ent.FPPOldColor.r, ent.FPPOldColor.g, ent.FPPOldColor.b, ent.FPPOldColor.a - 155))
 
     ent:SetCollisionGroup(COLLISION_GROUP_WORLD)
     ent.CollisionGroup = COLLISION_GROUP_WORLD
@@ -23,10 +23,10 @@ function FPP.UnGhost(ply, ent)
         ent:DrawShadow(true)
         if ent.OldCollisionGroup then ent:SetCollisionGroup(ent.OldCollisionGroup) ent.OldCollisionGroup = nil end
 
-        if IsColor(ent.OldColor) then
-            ent:SetColor(Color(ent.OldColor.r, ent.OldColor.g, ent.OldColor.b, ent.OldColor.a))
+        if ent.FPPOldColor then
+            ent:SetColor(Color(ent.FPPOldColor.r, ent.FPPOldColor.g, ent.FPPOldColor.b, ent.FPPOldColor.a))
         end
-        ent.OldColor = nil
+        ent.FPPOldColor = nil
 
 
         ent:SetCollisionGroup(COLLISION_GROUP_NONE)


### PR DESCRIPTION
Some addons can overwrite ent.OldColor with a non-color which causes errors like these:
```
[falcos-prop-protection-master] addons/falcos-prop-protection-master/lua/fpp/server/antispam.lua:9: attempt to index field 'OldColor' (a number value)
1. GhostFreeze - addons/falcos-prop-protection-master/lua/fpp/server/antispam.lua:9
 2. fn - addons/gmod_anticrash-main/lua/autorun/server/sv_anticrash_main.lua:47
  3. unknown - addons/ulib-master/lua/ulib/shared/hook.lua:109
```