### PR TITLE
Finding the owner of an entity correctly

### DIFF
--- a/lua/fpp/server/core.lua
+++ b/lua/fpp/server/core.lua
@@ -130,6 +130,14 @@ hook.Add("PlayerSpawnedSWEP", "FPP.Spawn.SWEP", function(ply, ent)
     ent:CPPISetOwner(ply)
 end)
 
+hook.Add("WeaponEquip", "FPP.Spawn.Weapon", function(weapon)
+    timer.Simple(0, function()
+        if IsValid(weapon) and IsValid(weapon:GetOwner()) and not IsValid(weapon:CPPIGetOwner()) then
+            weapon:CPPISetOwner(weapon:GetOwner())
+        end
+    end)
+end)
+
 hook.Add("PlayerSpawnedSENT", "FPP.Spawn.SENT", function(ply, ent)
     ent:CPPISetOwner(ply)
 end)


### PR DESCRIPTION
We already do this for weapons created by toolgun, but not for those given out via Q-menu or other means. I did this because some addons like Wiremod use CanTool for CPPI checks. But since we can't interact with our entity, some functions stop working (like weapon core).
It might be worth overwriting the weapon owner to always match :GetOwner(), but I'm not sure if that's what you want to do, so I copied the PlayerSpawnedSWEP behavior