### PR TITLE
Remove modified ENTITY:SetAngles()

### DIFF
--- a/lua/fpp/server/core.lua
+++ b/lua/fpp/server/core.lua
@@ -716,15 +716,3 @@ function constraint.CanConstrain(ent, bone)
 
     return canConstrain(ent, bone)
 end
-
--- Crash exploit workaround
-local setAngles = ENTITY.SetAngles
-function ENTITY:SetAngles(ang)
-    if not ang then return setAngles(self, ang) end
-
-    ang.p = ang.p % 360
-    ang.y = ang.y % 360
-    ang.r = ang.r % 360
-
-    return setAngles(self, ang)
-end


### PR DESCRIPTION
Maybe it was necessary before, but now if I try to specify some crazy values ​​in SetAngles, it will just give an error in the console
![image](https://github.com/user-attachments/assets/36d890c2-6bd8-4904-885f-89b7dbbc5e7f)