### PR TITLE
Make CPPI functions obey settings

### DIFF
--- a/lua/fpp/server/core.lua
+++ b/lua/fpp/server/core.lua
@@ -141,13 +141,13 @@ end)
 FPP.Protect = {}
 
 --Physgun Pickup
-function FPP.Protect.PhysgunPickup(ply, ent, internal)
-    if not tobool(FPP.Settings.FPP_PHYSGUN1.toggle) then if not internal and FPP.UnGhost then FPP.UnGhost(ply, ent) end return end
+function FPP.Protect.PhysgunPickup(ply, ent)
+    if not tobool(FPP.Settings.FPP_PHYSGUN1.toggle) then if FPP.UnGhost then FPP.UnGhost(ply, ent) end return end
     if not ent:IsValid() then return end
     local cantouch
     local skipReturn = false
 
-    if not internal and isfunction(ent.PhysgunPickup) then
+    if isfunction(ent.PhysgunPickup) then
         cantouch = ent:PhysgunPickup(ply, ent)
         -- Do not return the value, the gamemode will do this
         -- Allows other hooks to run
@@ -159,7 +159,7 @@ function FPP.Protect.PhysgunPickup(ply, ent, internal)
         skipReturn = ent:IsPlayer()
     end
 
-    if cantouch and not internal and FPP.UnGhost then FPP.UnGhost(ply, ent) end
+    if cantouch and FPP.UnGhost then FPP.UnGhost(ply, ent) end
     if not cantouch and not skipReturn then return false end
 end
 hook.Add("PhysgunPickup", "FPP.Protect.PhysgunPickup", FPP.Protect.PhysgunPickup)
@@ -205,7 +205,7 @@ end
 hook.Add("OnPhysgunFreeze", "FPP.Protect.PhysgunFreeze", FPP.PhysgunFreeze)
 
 --Gravgun pickup
-function FPP.Protect.GravGunPickup(ply, ent, internal)
+function FPP.Protect.GravGunPickup(ply, ent)
     if not tobool(FPP.Settings.FPP_GRAVGUN1.toggle) then return end
 
     if not IsValid(ent) then return end -- You don't want a cross when looking at the floor while holding right mouse
@@ -214,7 +214,7 @@ function FPP.Protect.GravGunPickup(ply, ent, internal)
 
     local cantouch
 
-    if not internal and isfunction(ent.GravGunPickup) then
+    if isfunction(ent.GravGunPickup) then
         cantouch = ent:GravGunPickup(ply, ent)
     elseif ent.GravGunPickup ~= nil then
         cantouch = ent.GravGunPickup
@@ -222,15 +222,15 @@ function FPP.Protect.GravGunPickup(ply, ent, internal)
         cantouch = not ent:IsPlayer() and FPP.plyCanTouchEnt(ply, ent, "Gravgun")
     end
 
-    if cantouch and not internal and FPP.UnGhost then FPP.UnGhost(ply, ent) end
-    if cantouch == false and not internal then DropEntityIfHeld(ent) end
+    if cantouch and FPP.UnGhost then FPP.UnGhost(ply, ent) end
+    if cantouch == false then DropEntityIfHeld(ent) end
 end
 hook.Add("GravGunOnPickedUp", "FPP.Protect.GravGunPickup", FPP.Protect.GravGunPickup)
 
-function FPP.Protect.CanGravGunPickup(ply, ent, internal)
+function FPP.Protect.CanGravGunPickup(ply, ent)
     if not tobool(FPP.Settings.FPP_GRAVGUN1.toggle) or not IsValid(ent) then return end
 
-    if not internal and isfunction(ent.GravGunPickup) then
+    if isfunction(ent.GravGunPickup) then
         -- Function name different than gamemode's (GravGunPickup vs GravGunPickupAllowed)
         -- Override FPP's behavior when implemented
         local val = ent:GravGunPickup(ply, ent)
@@ -250,17 +250,17 @@ end
 hook.Add("GravGunPickupAllowed", "FPP.Protect.CanGravGunPickup", FPP.Protect.CanGravGunPickup)
 
 --Gravgun punting
-function FPP.Protect.GravGunPunt(ply, ent, internal)
-    if tobool(FPP.Settings.FPP_GRAVGUN1.noshooting) then if not internal then DropEntityIfHeld(ent) end return false end
+function FPP.Protect.GravGunPunt(ply, ent)
+    if tobool(FPP.Settings.FPP_GRAVGUN1.noshooting) then DropEntityIfHeld(ent) return false end
     -- Do not reason further if gravgun protection is disabled.
     if not tobool(FPP.Settings.FPP_GRAVGUN1.toggle) then return end
 
-    if not IsValid(ent) then if not internal then DropEntityIfHeld(ent) end return end
+    if not IsValid(ent) then DropEntityIfHeld(ent) return end
 
     local cantouch
     local skipReturn = false
 
-    if not internal and isfunction(ent.GravGunPunt) then
+    if isfunction(ent.GravGunPunt) then
         cantouch = ent:GravGunPunt(ply, ent)
         -- Do not return the value, the gamemode will do this
         -- Allows other hooks to run
@@ -271,14 +271,14 @@ function FPP.Protect.GravGunPunt(ply, ent, internal)
         cantouch = not ent:IsPlayer() and FPP.plyCanTouchEnt(ply, ent, "Gravgun")
     end
 
-    if cantouch and not internal and FPP.UnGhost then FPP.UnGhost(ply, ent) end
-    if not cantouch and not internal then DropEntityIfHeld(ent) end
+    if cantouch and FPP.UnGhost then FPP.UnGhost(ply, ent) end
+    if not cantouch then DropEntityIfHeld(ent) end
     if not cantouch and not skipReturn then return false end
 end
 hook.Add("GravGunPunt", "FPP.Protect.GravGunPunt", FPP.Protect.GravGunPunt)
 
 --PlayerUse
-function FPP.Protect.PlayerUse(ply, ent, internal)
+function FPP.Protect.PlayerUse(ply, ent)
     if not tobool(FPP.Settings.FPP_PLAYERUSE1.toggle) then return end
 
     if not IsValid(ent) then return end
@@ -286,7 +286,7 @@ function FPP.Protect.PlayerUse(ply, ent, internal)
     local cantouch
     local skipReturn = false
 
-    if not internal and isfunction(ent.PlayerUse) then
+    if isfunction(ent.PlayerUse) then
         cantouch = ent:PlayerUse(ply, ent)
         -- Do not return the value, the gamemode will do this
         -- Allows other hooks to run
@@ -297,20 +297,20 @@ function FPP.Protect.PlayerUse(ply, ent, internal)
         cantouch = not ent:IsPlayer() and FPP.plyCanTouchEnt(ply, ent, "PlayerUse")
     end
 
-    if cantouch and not internal and FPP.UnGhost then FPP.UnGhost(ply, ent) end
+    if cantouch and FPP.UnGhost then FPP.UnGhost(ply, ent) end
     if not cantouch and not skipReturn then return false end
 end
 hook.Add("PlayerUse", "FPP.Protect.PlayerUse", FPP.Protect.PlayerUse)
 
 --EntityDamage
-function FPP.Protect.EntityDamage(ent, dmginfo, internal)
+function FPP.Protect.EntityDamage(ent, dmginfo)
     if not IsValid(ent) then return end
 
     local inflictor = dmginfo:GetInflictor()
     local attacker = dmginfo:GetAttacker()
     local amount = dmginfo:GetDamage()
 
-    if not internal and isfunction(ent.EntityDamage) then
+    if isfunction(ent.EntityDamage) then
         local val = ent:EntityDamage(ent, inflictor, attacker, amount, dmginfo)
         -- Do not return the value, the gamemode will do this
         if val ~= nil then return end
@@ -549,6 +549,7 @@ end
 hook.Add("CanTool", "FPP.Protect.CanTool", FPP.Protect.CanTool)
 
 function FPP.Protect.CanEditVariable(ent, ply, key, varVal, editTbl)
+    if not tobool(FPP.Settings.FPP_TOOLGUN1.toggle) then return true end
     local val = FPP.Protect.CanProperty(ply, "editentity", ent)
     if val ~= nil then return val end
 end
@@ -556,6 +557,7 @@ hook.Add("CanEditVariable", "FPP.Protect.CanEditVariable", FPP.Protect.CanEditVa
 
 function FPP.Protect.CanProperty(ply, property, ent)
     -- Use Toolgun because I'm way too lazy to make a new type
+    if not tobool(FPP.Settings.FPP_TOOLGUN1.toggle) then return true end
     local cantouch = FPP.plyCanTouchEnt(ply, ent, "Toolgun")
 
     if not cantouch then return false end
@@ -564,6 +566,7 @@ hook.Add("CanProperty", "FPP.Protect.CanProperty", FPP.Protect.CanProperty)
 
 function FPP.Protect.CanDrive(ply, ent)
     -- Use Toolgun because I'm way too lazy to make a new type
+    if not tobool(FPP.Settings.FPP_TOOLGUN1.toggle) then return true end
     local cantouch = FPP.plyCanTouchEnt(ply, ent, "Toolgun")
 
     if not cantouch then return false end

--- a/lua/fpp/server/core.lua
+++ b/lua/fpp/server/core.lua
@@ -142,7 +142,7 @@ FPP.Protect = {}
 
 --Physgun Pickup
 function FPP.Protect.PhysgunPickup(ply, ent, internal)
-    if not tobool(FPP.Settings.FPP_PHYSGUN1.toggle) and not internal then if FPP.UnGhost then FPP.UnGhost(ply, ent) end return end
+    if not tobool(FPP.Settings.FPP_PHYSGUN1.toggle) then if not internal and FPP.UnGhost then FPP.UnGhost(ply, ent) end return end
     if not ent:IsValid() then return end
     local cantouch
     local skipReturn = false

--- a/lua/fpp/server/core.lua
+++ b/lua/fpp/server/core.lua
@@ -223,7 +223,7 @@ function FPP.Protect.GravGunPickup(ply, ent, internal)
     end
 
     if cantouch and not internal and FPP.UnGhost then FPP.UnGhost(ply, ent) end
-    if cantouch == false then DropEntityIfHeld(ent) end
+    if cantouch == false and not internal then DropEntityIfHeld(ent) end
 end
 hook.Add("GravGunOnPickedUp", "FPP.Protect.GravGunPickup", FPP.Protect.GravGunPickup)
 
@@ -255,7 +255,7 @@ function FPP.Protect.GravGunPunt(ply, ent, internal)
     -- Do not reason further if gravgun protection is disabled.
     if not tobool(FPP.Settings.FPP_GRAVGUN1.toggle) then return end
 
-    if not IsValid(ent) then DropEntityIfHeld(ent) return end
+    if not IsValid(ent) then if not internal then DropEntityIfHeld(ent) end return end
 
     local cantouch
     local skipReturn = false
@@ -272,7 +272,7 @@ function FPP.Protect.GravGunPunt(ply, ent, internal)
     end
 
     if cantouch and not internal and FPP.UnGhost then FPP.UnGhost(ply, ent) end
-    if not cantouch then DropEntityIfHeld(ent) end
+    if not cantouch and not internal then DropEntityIfHeld(ent) end
     if not cantouch and not skipReturn then return false end
 end
 hook.Add("GravGunPunt", "FPP.Protect.GravGunPunt", FPP.Protect.GravGunPunt)

--- a/lua/fpp/server/core.lua
+++ b/lua/fpp/server/core.lua
@@ -141,8 +141,8 @@ end)
 FPP.Protect = {}
 
 --Physgun Pickup
-function FPP.Protect.PhysgunPickup(ply, ent)
-    if not tobool(FPP.Settings.FPP_PHYSGUN1.toggle) then if FPP.UnGhost then FPP.UnGhost(ply, ent) end return end
+function FPP.Protect.PhysgunPickup(ply, ent, internal)
+    if not tobool(FPP.Settings.FPP_PHYSGUN1.toggle) and not internal then if FPP.UnGhost then FPP.UnGhost(ply, ent) end return end
     if not ent:IsValid() then return end
     local cantouch
     local skipReturn = false
@@ -159,7 +159,7 @@ function FPP.Protect.PhysgunPickup(ply, ent)
         skipReturn = ent:IsPlayer()
     end
 
-    if cantouch and FPP.UnGhost then FPP.UnGhost(ply, ent) end
+    if cantouch and not internal and FPP.UnGhost then FPP.UnGhost(ply, ent) end
     if not cantouch and not skipReturn then return false end
 end
 hook.Add("PhysgunPickup", "FPP.Protect.PhysgunPickup", FPP.Protect.PhysgunPickup)
@@ -205,7 +205,7 @@ end
 hook.Add("OnPhysgunFreeze", "FPP.Protect.PhysgunFreeze", FPP.PhysgunFreeze)
 
 --Gravgun pickup
-function FPP.Protect.GravGunPickup(ply, ent)
+function FPP.Protect.GravGunPickup(ply, ent, internal)
     if not tobool(FPP.Settings.FPP_GRAVGUN1.toggle) then return end
 
     if not IsValid(ent) then return end -- You don't want a cross when looking at the floor while holding right mouse
@@ -222,7 +222,7 @@ function FPP.Protect.GravGunPickup(ply, ent)
         cantouch = not ent:IsPlayer() and FPP.plyCanTouchEnt(ply, ent, "Gravgun")
     end
 
-    if cantouch and FPP.UnGhost then FPP.UnGhost(ply, ent) end
+    if cantouch and not internal and FPP.UnGhost then FPP.UnGhost(ply, ent) end
     if cantouch == false then DropEntityIfHeld(ent) end
 end
 hook.Add("GravGunOnPickedUp", "FPP.Protect.GravGunPickup", FPP.Protect.GravGunPickup)
@@ -250,7 +250,7 @@ end
 hook.Add("GravGunPickupAllowed", "FPP.Protect.CanGravGunPickup", FPP.Protect.CanGravGunPickup)
 
 --Gravgun punting
-function FPP.Protect.GravGunPunt(ply, ent)
+function FPP.Protect.GravGunPunt(ply, ent, internal)
     if tobool(FPP.Settings.FPP_GRAVGUN1.noshooting) then DropEntityIfHeld(ent) return false end
     -- Do not reason further if gravgun protection is disabled.
     if not tobool(FPP.Settings.FPP_GRAVGUN1.toggle) then return end
@@ -271,14 +271,14 @@ function FPP.Protect.GravGunPunt(ply, ent)
         cantouch = not ent:IsPlayer() and FPP.plyCanTouchEnt(ply, ent, "Gravgun")
     end
 
-    if cantouch and FPP.UnGhost then FPP.UnGhost(ply, ent) end
+    if cantouch and not internal and FPP.UnGhost then FPP.UnGhost(ply, ent) end
     if not cantouch then DropEntityIfHeld(ent) end
     if not cantouch and not skipReturn then return false end
 end
 hook.Add("GravGunPunt", "FPP.Protect.GravGunPunt", FPP.Protect.GravGunPunt)
 
 --PlayerUse
-function FPP.Protect.PlayerUse(ply, ent)
+function FPP.Protect.PlayerUse(ply, ent, internal)
     if not tobool(FPP.Settings.FPP_PLAYERUSE1.toggle) then return end
 
     if not IsValid(ent) then return end
@@ -297,7 +297,7 @@ function FPP.Protect.PlayerUse(ply, ent)
         cantouch = not ent:IsPlayer() and FPP.plyCanTouchEnt(ply, ent, "PlayerUse")
     end
 
-    if cantouch and FPP.UnGhost then FPP.UnGhost(ply, ent) end
+    if cantouch and not internal and FPP.UnGhost then FPP.UnGhost(ply, ent) end
     if not cantouch and not skipReturn then return false end
 end
 hook.Add("PlayerUse", "FPP.Protect.PlayerUse", FPP.Protect.PlayerUse)

--- a/lua/fpp/server/core.lua
+++ b/lua/fpp/server/core.lua
@@ -147,7 +147,7 @@ function FPP.Protect.PhysgunPickup(ply, ent, internal)
     local cantouch
     local skipReturn = false
 
-    if isfunction(ent.PhysgunPickup) then
+    if not internal and isfunction(ent.PhysgunPickup) then
         cantouch = ent:PhysgunPickup(ply, ent)
         -- Do not return the value, the gamemode will do this
         -- Allows other hooks to run
@@ -214,7 +214,7 @@ function FPP.Protect.GravGunPickup(ply, ent, internal)
 
     local cantouch
 
-    if isfunction(ent.GravGunPickup) then
+    if not internal and isfunction(ent.GravGunPickup) then
         cantouch = ent:GravGunPickup(ply, ent)
     elseif ent.GravGunPickup ~= nil then
         cantouch = ent.GravGunPickup
@@ -260,7 +260,7 @@ function FPP.Protect.GravGunPunt(ply, ent, internal)
     local cantouch
     local skipReturn = false
 
-    if isfunction(ent.GravGunPunt) then
+    if not internal and isfunction(ent.GravGunPunt) then
         cantouch = ent:GravGunPunt(ply, ent)
         -- Do not return the value, the gamemode will do this
         -- Allows other hooks to run
@@ -286,7 +286,7 @@ function FPP.Protect.PlayerUse(ply, ent, internal)
     local cantouch
     local skipReturn = false
 
-    if isfunction(ent.PlayerUse) then
+    if not internal and isfunction(ent.PlayerUse) then
         cantouch = ent:PlayerUse(ply, ent)
         -- Do not return the value, the gamemode will do this
         -- Allows other hooks to run
@@ -303,14 +303,14 @@ end
 hook.Add("PlayerUse", "FPP.Protect.PlayerUse", FPP.Protect.PlayerUse)
 
 --EntityDamage
-function FPP.Protect.EntityDamage(ent, dmginfo)
+function FPP.Protect.EntityDamage(ent, dmginfo, internal)
     if not IsValid(ent) then return end
 
     local inflictor = dmginfo:GetInflictor()
     local attacker = dmginfo:GetAttacker()
     local amount = dmginfo:GetDamage()
 
-    if isfunction(ent.EntityDamage) then
+    if not internal and isfunction(ent.EntityDamage) then
         local val = ent:EntityDamage(ent, inflictor, attacker, amount, dmginfo)
         -- Do not return the value, the gamemode will do this
         if val ~= nil then return end

--- a/lua/fpp/server/core.lua
+++ b/lua/fpp/server/core.lua
@@ -251,7 +251,7 @@ hook.Add("GravGunPickupAllowed", "FPP.Protect.CanGravGunPickup", FPP.Protect.Can
 
 --Gravgun punting
 function FPP.Protect.GravGunPunt(ply, ent, internal)
-    if tobool(FPP.Settings.FPP_GRAVGUN1.noshooting) then DropEntityIfHeld(ent) return false end
+    if tobool(FPP.Settings.FPP_GRAVGUN1.noshooting) then if not internal then DropEntityIfHeld(ent) end return false end
     -- Do not reason further if gravgun protection is disabled.
     if not tobool(FPP.Settings.FPP_GRAVGUN1.toggle) then return end
 

--- a/lua/fpp/server/core.lua
+++ b/lua/fpp/server/core.lua
@@ -227,10 +227,10 @@ function FPP.Protect.GravGunPickup(ply, ent, internal)
 end
 hook.Add("GravGunOnPickedUp", "FPP.Protect.GravGunPickup", FPP.Protect.GravGunPickup)
 
-function FPP.Protect.CanGravGunPickup(ply, ent)
+function FPP.Protect.CanGravGunPickup(ply, ent, internal)
     if not tobool(FPP.Settings.FPP_GRAVGUN1.toggle) or not IsValid(ent) then return end
 
-    if isfunction(ent.GravGunPickup) then
+    if not internal and isfunction(ent.GravGunPickup) then
         -- Function name different than gamemode's (GravGunPickup vs GravGunPickupAllowed)
         -- Override FPP's behavior when implemented
         local val = ent:GravGunPickup(ply, ent)

--- a/lua/fpp/sh_cppi.lua
+++ b/lua/fpp/sh_cppi.lua
@@ -72,32 +72,28 @@ if SERVER then
     end
 
     function ENTITY:CPPICanPhysgun(ply)
-        local canphysgun = FPP.Protect.PhysgunPickup(ply, self, true)
-        return canphysgun == nil and true or canphysgun
+        if not tobool(FPP.Settings.FPP_PHYSGUN1.toggle) then return true end
+        return FPP.plyCanTouchEnt(ply, self, "Physgun")
     end
 
     function ENTITY:CPPICanPickup(ply)
-        local canpickup = FPP.Protect.CanGravGunPickup(ply, self)
-        return canpickup == nil and true or canpickup
+        if not tobool(FPP.Settings.FPP_PHYSGUN1.toggle) then return true end
+        return FPP.plyCanTouchEnt(ply, self, "Gravgun")
     end
 
     function ENTITY:CPPICanPunt(ply)
-        local canpunt = FPP.Protect.GravGunPunt(ply, self, true)
-        return canpunt == nil and true or canpunt
+        if not tobool(FPP.Settings.FPP_GRAVGUN1.toggle) then return true end
+        return FPP.plyCanTouchEnt(ply, self, "Gravgun")
     end
 
     function ENTITY:CPPICanUse(ply)
-        local canuse = FPP.Protect.PlayerUse(ply, self, true)
-        return canuse == nil and true or canuse
+        if not tobool(FPP.Settings.FPP_PLAYERUSE1.toggle) then return true end
+        return FPP.plyCanTouchEnt(ply, self, "PlayerUse")
     end
 
     function ENTITY:CPPICanDamage(ply)
-        local dmginfo = DamageInfo()
-        dmginfo:SetAttacker(ply)
-        dmginfo:SetDamage(-1)
-
-        FPP.Protect.EntityDamage(self, dmginfo, true)
-        return dmginfo:GetDamage() == -1
+        if not tobool(FPP.Settings.FPP_ENTITYDAMAGE1.toggle) then return true end
+        return FPP.plyCanTouchEnt(ply, self, "EntityDamage")
     end
 
     function ENTITY:CPPIDrive(ply)

--- a/lua/fpp/sh_cppi.lua
+++ b/lua/fpp/sh_cppi.lua
@@ -96,8 +96,8 @@ if SERVER then
         dmginfo:SetAttacker(ply)
         dmginfo:SetDamage(-1)
 
-        FPP.Protect.EntityDamage(self, dmginfo)
-        return dmginfo:GetDamage() ~= 0
+        FPP.Protect.EntityDamage(self, dmginfo, true)
+        return dmginfo:GetDamage() == -1
     end
 
     function ENTITY:CPPIDrive(ply)

--- a/lua/fpp/sh_cppi.lua
+++ b/lua/fpp/sh_cppi.lua
@@ -72,7 +72,7 @@ if SERVER then
     end
 
     function ENTITY:CPPICanPhysgun(ply)
-        local canphysgun = FPP.Protect.PhysgunPickup(ply, self)
+        local canphysgun = FPP.Protect.PhysgunPickup(ply, self, true)
         return canphysgun == nil and true or canphysgun
     end
 
@@ -82,12 +82,12 @@ if SERVER then
     end
 
     function ENTITY:CPPICanPunt(ply)
-        local canpunt = FPP.Protect.GravGunPunt(ply, self)
+        local canpunt = FPP.Protect.GravGunPunt(ply, self, true)
         return canpunt == nil and true or canpunt
     end
 
     function ENTITY:CPPICanUse(ply)
-        local canuse = FPP.Protect.PlayerUse(ply, self)
+        local canuse = FPP.Protect.PlayerUse(ply, self, true)
         return canuse == nil and true or canuse
     end
 

--- a/lua/fpp/sh_cppi.lua
+++ b/lua/fpp/sh_cppi.lua
@@ -67,41 +67,54 @@ if SERVER then
     end
 
     function ENTITY:CPPICanTool(ply, tool)
-        local Value = FPP.Protect.CanTool(ply, nil, tool, self)
-        if Value ~= false and Value ~= true then Value = true end
-        return Value
+        local cantool = FPP.Protect.CanTool(ply, nil, tool, self)
+        if cantool == nil then cantool = true end
+        return cantool
     end
 
     function ENTITY:CPPICanPhysgun(ply)
-        return FPP.plyCanTouchEnt(ply, self, "Physgun")
+        local canphysgun = FPP.Protect.PhysgunPickup(ply, self)
+        if canphysgun == nil then canphysgun = true end
+        return canphysgun
     end
 
     function ENTITY:CPPICanPickup(ply)
-        return FPP.plyCanTouchEnt(ply, self, "Gravgun")
+        local canpickup = FPP.Protect.CanGravGunPickup(ply, self)
+        if canpickup == nil then canpickup = true end
+        return canpickup
     end
 
     function ENTITY:CPPICanPunt(ply)
-        return FPP.plyCanTouchEnt(ply, self, "Gravgun")
+        local canpunt = FPP.Protect.GravGunPunt(ply, self)
+        if canpunt == nil then canpunt = true end
+        return canpunt
     end
 
     function ENTITY:CPPICanUse(ply)
-        return FPP.plyCanTouchEnt(ply, self, "PlayerUse")
+        local canuse = FPP.Protect.PlayerUse(ply, self)
+        if canuse == nil then canuse = true end
+        return canuse
     end
 
     function ENTITY:CPPICanDamage(ply)
-        return FPP.plyCanTouchEnt(ply,  self, "EntityDamage")
+        local dmginfo = DamageInfo()
+        dmginfo:SetAttacker(ply)
+        dmginfo:SetDamage(-1)
+
+        FPP.Protect.EntityDamage(self, dmginfo)
+        return dmginfo:GetDamage() ~= 0
     end
 
     function ENTITY:CPPIDrive(ply)
-        local Value = FPP.Protect.CanDrive(ply, self)
-        if Value ~= false and Value ~= true then Value = true end
-        return Value
+        local candrive = FPP.Protect.CanDrive(ply, self)
+        if candrive == nil then candrive = true end
+        return candrive
     end
 
     function ENTITY:CPPICanProperty(ply, property)
-        local Value = FPP.Protect.CanProperty(ply, property, self)
-        if Value ~= false and Value ~= true then Value = true end
-        return Value
+        local canproperty = FPP.Protect.CanProperty(ply, property, self)
+        if canproperty == nil then canproperty = true end
+        return canproperty
     end
 
     function ENTITY:CPPICanEditVariable(ply, key, val, editTbl)

--- a/lua/fpp/sh_cppi.lua
+++ b/lua/fpp/sh_cppi.lua
@@ -62,38 +62,33 @@ if SERVER then
 
     function ENTITY:CPPISetOwnerUID(UID)
         local ply = UID and player.GetByUniqueID(tostring(UID)) or nil
-        if UID and not IsValid(ply) then return false end
+        if UID and not ply then return false end
         return self:CPPISetOwner(ply)
     end
 
     function ENTITY:CPPICanTool(ply, tool)
         local cantool = FPP.Protect.CanTool(ply, nil, tool, self)
-        if cantool == nil then cantool = true end
-        return cantool
+        return cantool == nil and true or cantool
     end
 
     function ENTITY:CPPICanPhysgun(ply)
         local canphysgun = FPP.Protect.PhysgunPickup(ply, self)
-        if canphysgun == nil then canphysgun = true end
-        return canphysgun
+        return canphysgun == nil and true or canphysgun
     end
 
     function ENTITY:CPPICanPickup(ply)
         local canpickup = FPP.Protect.CanGravGunPickup(ply, self)
-        if canpickup == nil then canpickup = true end
-        return canpickup
+        return canpickup == nil and true or canpickup
     end
 
     function ENTITY:CPPICanPunt(ply)
         local canpunt = FPP.Protect.GravGunPunt(ply, self)
-        if canpunt == nil then canpunt = true end
-        return canpunt
+        return canpunt == nil and true or canpunt
     end
 
     function ENTITY:CPPICanUse(ply)
         local canuse = FPP.Protect.PlayerUse(ply, self)
-        if canuse == nil then canuse = true end
-        return canuse
+        return canuse == nil and true or canuse
     end
 
     function ENTITY:CPPICanDamage(ply)
@@ -107,14 +102,12 @@ if SERVER then
 
     function ENTITY:CPPIDrive(ply)
         local candrive = FPP.Protect.CanDrive(ply, self)
-        if candrive == nil then candrive = true end
-        return candrive
+        return candrive == nil and true or candrive
     end
 
     function ENTITY:CPPICanProperty(ply, property)
         local canproperty = FPP.Protect.CanProperty(ply, property, self)
-        if canproperty == nil then canproperty = true end
-        return canproperty
+        return canproperty == nil and true or canproperty
     end
 
     function ENTITY:CPPICanEditVariable(ply, key, val, editTbl)


### PR DESCRIPTION
Modifies CPPI functions to make them work more correctly. For example, this fixes returning false in CPPICanDamage when damage protection is disabled.