### PR TITLE
Improved version of the weapon owner

### DIFF
--- a/lua/fpp/sh_cppi.lua
+++ b/lua/fpp/sh_cppi.lua
@@ -45,7 +45,10 @@ function WEAPON:CPPIGetOwner()
     local owner = ENTITY.CPPIGetOwner(self)
     if IsValid(owner) then return owner end
 
-    return ENTITY.GetOwner(self)
+    owner = ENTITY.GetOwner(self)
+    if not owner:IsValid() then return nil, self.FPPOwnerID end
+
+    return owner, owner:UniqueID()
 end
 
 if SERVER then

--- a/lua/fpp/sh_cppi.lua
+++ b/lua/fpp/sh_cppi.lua
@@ -42,11 +42,11 @@ end
 local WEAPON = FindMetaTable("Weapon")
 
 function WEAPON:CPPIGetOwner()
-    local owner = ENTITY.CPPIGetOwner(self)
-    if IsValid(owner) then return owner end
+    local owner, ownerid = ENTITY.CPPIGetOwner(self)
+    if IsValid(owner) then return owner, ownerid end
 
     owner = ENTITY.GetOwner(self)
-    if not owner:IsValid() then return nil, self.FPPOwnerID end
+    if not owner:IsValid() or not owner:IsPlayer() then return SERVER and owner or nil, self.FPPOwnerID end
 
     return owner, owner:UniqueID()
 end

--- a/lua/fpp/sh_cppi.lua
+++ b/lua/fpp/sh_cppi.lua
@@ -32,10 +32,20 @@ function PLAYER:CPPIGetFriends()
 end
 
 local ENTITY = FindMetaTable("Entity")
+
 function ENTITY:CPPIGetOwner()
     local Owner = FPP.entGetOwner(self)
     if not IsValid(Owner) or not Owner:IsPlayer() then return SERVER and Owner or nil, self.FPPOwnerID end
     return Owner, Owner:UniqueID()
+end
+
+local WEAPON = FindMetaTable("Weapon")
+
+function WEAPON:CPPIGetOwner()
+    local owner = ENTITY.CPPIGetOwner(self)
+    if IsValid(owner) then return owner end
+
+    return ENTITY.GetOwner(self)
 end
 
 if SERVER then


### PR DESCRIPTION
This PR is an improved version of #340 which simply overrides CPPIGetOwner for weapons.

Now if you call CPPIGetOwner on a weapon, it will first check if there is already a specific owner for this weapon, if not, it will call ENTITY:GetOwner to return the owner. This fix will allow Sandbox players to modify their weapons using addons that use CanTool checks.