### PR TITLE
Make `GetTable` local in `FPP.entGetOwner`

### DIFF
--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -273,8 +273,10 @@ function FPP.plyCanTouchEnt(ply, ent, touchType)
     return bit_bor(canTouch, touchTypes[touchType]) == canTouch
 end
 
+local GetTable = entMeta.GetTable
+
 function FPP.entGetOwner(ent)
-    return ent:GetTable().FPPOwner
+    return GetTable(ent).FPPOwner
 end
 
 --[[-------------------------------------------------------------------------


### PR DESCRIPTION
Optimizes `FPP.entGetOwner` even more by not doing any `__index` calls