### PR TITLE
Some serverside ownership optimizations

### DIFF
--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -397,7 +397,7 @@ local function onEntitiesCreated(ents)
 
         if blockedEnts[ent:GetClass()] then continue end
 
-        for _, ply in player.Iterator() do
+        for _, ply in ipairs(player.GetAll()) do
             local changed = FPP.calculateCanTouch(ply, ent)
             -- Only send data that has been changed
             if not changed then continue end

--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -294,31 +294,35 @@ local function netWriteEntData(ply, ent)
     net.WriteUInt(entTable.FPPConstraintReasons and entTable.FPPConstraintReasons[ply] or entTable.FPPCanTouchWhy[ply], 20) -- reasons
 end
 
+-- The net message gets too big with 5826 or more entities. In that case,
+-- break up the input into chunks and recurse per chunk.
+--
+-- Note: There is still a limit on the entity count! If there are too many
+-- entities, the client will disconnect with "Disconnect: Client 0
+-- overflowed reliable channel..". That limit is above the entity limit of
+-- 16384, though, so no further work is done to lift that limit.
+local count_limit = 5825
+
 function FPP.plySendTouchData(ply, ents)
     local count = #ents
-
     if count == 0 then return end
 
-    -- The net message gets too big with 5826 or more entities. In that case,
-    -- break up the input into chunks and recurse per chunk.
-    --
-    -- Note: There is still a limit on the entity count! If there are too many
-    -- entities, the client will disconnect with "Disconnect: Client 0
-    -- overflowed reliable channel..". That limit is above the entity limit of
-    -- 16384, though, so no further work is done to lift that limit.
-    local count_limit = 5825
     if count > count_limit then
         local accumulator = {}
+
         for i = 1, count do
             table.insert(accumulator, ents[i])
+
             if i % count_limit == 0 then
                 FPP.plySendTouchData(ply, accumulator)
-                table.Empty(accumulator)
+                accumulator = {}
             end
         end
+
         if #accumulator > 0 then
             FPP.plySendTouchData(ply, accumulator)
         end
+
         return
     end
 
@@ -378,8 +382,8 @@ local function onEntitiesCreated(ents)
     -- Table from player to list of entities that need to be networked
     local sendToPlayers = {}
 
-    for _, ent in pairs(ents) do
-        if not IsValid(ent) then continue end
+    for _, ent in ipairs(ents) do
+        if not ent:IsValid() then continue end
 
         if isConstraint(ent) then
             handleConstraintCreation(ent)
@@ -393,7 +397,7 @@ local function onEntitiesCreated(ents)
 
         if blockedEnts[ent:GetClass()] then continue end
 
-        for _, ply in ipairs(player.GetAll()) do
+        for _, ply in player.Iterator() do
             local changed = FPP.calculateCanTouch(ply, ent)
             -- Only send data that has been changed
             if not changed then continue end


### PR DESCRIPTION
A small optimization aimed at moments when the server has a large online and a lot of entities are creating
* Don't use `table.Empty` (terrible solution)
* Using `ipairs` instead of `pairs`
* Using `player.Iterator` instead of `player.GetAll`
* Move `count_limit` outside