### PR TITLE
Fix for physgun blocked entities

### DIFF
--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -105,8 +105,11 @@ local function calculateCanTouchForType(ply, ent, touchType)
         local adminsCanTouchBlocked = FPPSettings.admincanblocked ~= 0
         local playersCanBlocked = FPPSettings.canblocked ~= 0
 
-        return (playersCanBlocked or isAdmin and adminsCanTouchBlocked) and not getPlySetting(ply, "FPP_PrivateSettings_BlockedProps"),
-               reasonNumbers.blocked
+        local canPhysgunBlocked = (playersCanBlocked or isAdmin and adminsCanTouchBlocked) and not getPlySetting(ply, "FPP_PrivateSettings_BlockedProps")
+
+        if not canPhysgunBlocked then
+            return canPhysgunBlocked, reasonNumbers.blocked
+        end
     end
 
     -- touch own props


### PR DESCRIPTION
If world physgun is disabled and block entity physgun is enabled, the player will be able to physgun the blocked world entity