### PR TITLE
Networking improvements

### DIFF
--- a/lua/fpp/client/ownability.lua
+++ b/lua/fpp/client/ownability.lua
@@ -24,21 +24,23 @@ local reasons = {
     [8] = "player", -- you can't pick up players
 }
 
+local MAX_PLAYER_BITS = math.ceil(math.log(1 + game.MaxPlayers()) / math.log(2))
+
 local function receiveTouchData(len)
-    repeat
-        local entIndex = net.ReadUInt(13)
-        local ownerIndex = net.ReadUInt(8)
+    for i = 1, net.ReadUInt(MAX_EDICT_BITS) do
+        local entIndex = net.ReadUInt(MAX_EDICT_BITS)
+        local ownerIndex = net.ReadUInt(MAX_PLAYER_BITS)
         local touchability = net.ReadUInt(5)
         local reason = net.ReadUInt(20)
 
-        if ownerIndex == 255 then
+        if ownerIndex == 0 then
             ownerIndex = -1
         end
 
         FPP.entOwners[entIndex] = ownerIndex
         FPP.entTouchability[entIndex] = touchability
         FPP.entTouchReasons[entIndex] = reason
-    until net.ReadBit() == 1
+    end
 end
 net.Receive("FPP_TouchabilityData", receiveTouchData)
 

--- a/lua/fpp/client/ownability.lua
+++ b/lua/fpp/client/ownability.lua
@@ -27,7 +27,7 @@ local reasons = {
 local MAX_PLAYER_BITS = math.ceil(math.log(1 + game.MaxPlayers()) / math.log(2))
 
 local function receiveTouchData(len)
-    for i = 1, net.ReadUInt(MAX_EDICT_BITS) do
+    repeat
         local entIndex = net.ReadUInt(MAX_EDICT_BITS)
         local ownerIndex = net.ReadUInt(MAX_PLAYER_BITS)
         local touchability = net.ReadUInt(5)
@@ -40,7 +40,7 @@ local function receiveTouchData(len)
         FPP.entOwners[entIndex] = ownerIndex
         FPP.entTouchability[entIndex] = touchability
         FPP.entTouchReasons[entIndex] = reason
-    end
+    until net.ReadBit() == 1
 end
 net.Receive("FPP_TouchabilityData", receiveTouchData)
 

--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -287,7 +287,7 @@ Networking
 ---------------------------------------------------------------------------]]
 util.AddNetworkString("FPP_TouchabilityData")
 
--- Sends MAX_EDICT_BITS(13) + (1, 8) + 5 + 20 = 46 bits of ownership data per entity
+-- Sends MAX_EDICT_BITS(13) + (1, 8) + 5 + 20 = (39, 46) bits of ownership data per entity
 local MAX_PLAYER_BITS = math.ceil(math.log(1 + game.MaxPlayers()) / math.log(2))
 
 local function netWriteEntData(ply, ent)

--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -287,8 +287,13 @@ Networking
 ---------------------------------------------------------------------------]]
 util.AddNetworkString("FPP_TouchabilityData")
 
--- Sends MAX_EDICT_BITS(13) + (1, 8) + 5 + 20 = (39, 46) bits of ownership data per entity
+-- MAX_PLAYER_BITS is the minimum amount of bits needed to refer to a player.
+-- Given that there's a hard maximum of 128 players on a server. MAX_PLAYER_BITS
+-- will hold a value between 1 and 8 inclusive.
 local MAX_PLAYER_BITS = math.ceil(math.log(1 + game.MaxPlayers()) / math.log(2))
+--
+-- Sends MAX_EDICT_BITS(13) + MAX_PLAYER_BITS(between 1 and 8) + 5 + 20 = between 39 and 46 bits of
+-- ownership data per entity
 
 local function netWriteEntData(ply, ent)
     -- EntIndex for when it's out of the PVS of the player

--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -340,10 +340,9 @@ function FPP.plySendTouchData(ply, ents)
     end
 
     net.Start("FPP_TouchabilityData")
-        net.WriteUInt(count, MAX_EDICT_BITS)
-
         for i = 1, count do
             netWriteEntData(ply, ents[i])
+            net.WriteBit(i == count)
         end
     net.Send(ply)
 end


### PR DESCRIPTION
Uses enums MAX_EDICT_BITS and MAX_PLAYER_BITS. The first one if something changes with edict limit, and the second one will save us from 0 to 7 bits. Also, when receiving touch data, an extra bit is not written each time, but the length is written once